### PR TITLE
Priority queue

### DIFF
--- a/source/simulation2/components/CCmpPathfinder_Vertex.cpp
+++ b/source/simulation2/components/CCmpPathfinder_Vertex.cpp
@@ -333,7 +333,7 @@ CFixedVector2D CCmpPathfinder::GetNearestPointOnGoal(CFixedVector2D pos, const P
 	// cost of a virtual call inside ComputeShortPath)
 }
 
-typedef PriorityQueueHeap<u16, fixed> VertexPriorityQueue;
+typedef PriorityQueueHeap<u16, fixed, fixed> VertexPriorityQueue;
 
 /**
  * Add edges and vertexes to represent the boundaries between passable and impassable
@@ -862,7 +862,7 @@ void CCmpPathfinder::ComputeShortPath(const IObstructionTestFilter& filter,
 	PROFILE_START("A*");
 
 	VertexPriorityQueue open;
-	VertexPriorityQueue::Item qiStart = { START_VERTEX_ID, start.h };
+	VertexPriorityQueue::Item qiStart = { START_VERTEX_ID, start.h, start.h };
 	open.push(qiStart);
 
 	u16 idBest = START_VERTEX_ID;
@@ -976,7 +976,7 @@ void CCmpPathfinder::ComputeShortPath(const IObstructionTestFilter& filter,
 					if (n == GOAL_VERTEX_ID)
 						vertexes[n].p = npos; // remember the new best goal position
 
-					VertexPriorityQueue::Item t = { (u16)n, g + vertexes[n].h };
+					VertexPriorityQueue::Item t = { (u16)n, g + vertexes[n].h, vertexes[n].h };
 					open.push(t);
 
 					// Remember the heuristically best vertex we've seen so far, in case we never actually reach the target
@@ -1006,7 +1006,7 @@ void CCmpPathfinder::ComputeShortPath(const IObstructionTestFilter& filter,
 					if (n == GOAL_VERTEX_ID)
 						vertexes[n].p = npos; // remember the new best goal position
 
-					open.promote((u16)n, gprev + vertexes[n].h, g + vertexes[n].h);
+					open.promote((u16)n, gprev + vertexes[n].h, g + vertexes[n].h, vertexes[n].h);
 				}
 			}
 		}

--- a/source/simulation2/components/CCmpTerritoryManager.cpp
+++ b/source/simulation2/components/CCmpTerritoryManager.cpp
@@ -295,7 +295,7 @@ of extending to each neighbour (based on radius-determining 'falloff' value,
 adjusted by terrain movement cost), and repeating until all tiles are processed.
 */
 
-typedef PriorityQueueHeap<std::pair<u16, u16>, u32, std::greater<u32> > OpenQueue;
+typedef PriorityQueueHeap<std::pair<u16, u16>, u32, u32, std::greater<u32> > OpenQueue;
 
 static void ProcessNeighbour(u32 falloff, int i, int j, u32 pg, bool diagonal,
 		Grid<u32>& grid, OpenQueue& queue, const Grid<u8>& costGrid)
@@ -312,7 +312,7 @@ static void ProcessNeighbour(u32 falloff, int i, int j, u32 pg, bool diagonal,
 	u32 g = pg - dg; // cost to this tile = cost to predecessor - falloff from predecessor
 
 	grid.set(i, j, g);
-	OpenQueue::Item tile = { std::make_pair((u16)i, (u16)j), g };
+	OpenQueue::Item tile = { std::make_pair((u16)i, (u16)j), g, g };
 	queue.push(tile);
 }
 
@@ -498,7 +498,7 @@ void CCmpTerritoryManager::CalculateTerritories()
 			// Initialise the tile under the entity
 			entityGrid.set(i, j, weight);
 			OpenQueue openTiles;
-			OpenQueue::Item tile = { std::make_pair((u16)i, (i16)j), weight };
+			OpenQueue::Item tile = { std::make_pair((u16)i, (i16)j), weight, weight };
 			openTiles.push(tile);
 
 			// Expand influences outwards

--- a/source/simulation2/helpers/LongPathfinder.h
+++ b/source/simulation2/helpers/LongPathfinder.h
@@ -131,7 +131,7 @@ struct CircularRegion
 	entity_pos_t x, z, r;
 };
 
-typedef PriorityQueueHeap<TileID, PathCost> PriorityQueue;
+typedef PriorityQueueHeap<TileID, PathCost, PathCost> PriorityQueue;
 typedef SparseGrid<PathfindTile> PathfindTileGrid;
 
 class JumpPointCache;
@@ -295,9 +295,9 @@ private:
 	 * @param detectGoal is not used if m_UseJPSCache is true
 	 */
 	void AddJumpedHoriz(int i, int j, int di, PathCost g, PathfinderState& state, bool detectGoal);
-	bool HasJumpedHoriz(int i, int j, int di, PathfinderState& state, bool detectGoal);
+	int HasJumpedHoriz(int i, int j, int di, PathfinderState& state, bool detectGoal);
 	void AddJumpedVert(int i, int j, int dj, PathCost g, PathfinderState& state, bool detectGoal);
-	bool HasJumpedVert(int i, int j, int dj, PathfinderState& state, bool detectGoal);
+	int HasJumpedVert(int i, int j, int dj, PathfinderState& state, bool detectGoal);
 	void AddJumpedDiag(int i, int j, int di, int dj, PathCost g, PathfinderState& state);
 
 	/**

--- a/source/simulation2/helpers/Pathfinding.h
+++ b/source/simulation2/helpers/Pathfinding.h
@@ -76,6 +76,13 @@ struct PathCost
 		return c;
 	}
 
+	PathCost operator+=(const PathCost& a)
+	{
+		PathCost c;
+		data += a.data;
+		return *this;
+	}
+
 	bool operator<=(const PathCost& b) const { return data <= b.data; }
 	bool operator< (const PathCost& b) const { return data <  b.data; }
 	bool operator>=(const PathCost& b) const { return data >= b.data; }

--- a/source/simulation2/helpers/Pathfinding.h
+++ b/source/simulation2/helpers/Pathfinding.h
@@ -76,9 +76,8 @@ struct PathCost
 		return c;
 	}
 
-	PathCost operator+=(const PathCost& a)
+	PathCost& operator+=(const PathCost& a)
 	{
-		PathCost c;
 		data += a.data;
 		return *this;
 	}


### PR DESCRIPTION
I took some profiles. [Replay data](http://1drv.ms/1EQqtFL)  is based on "We Are Region", AI vs AI, so I hope we could compare between different versions, including main branch. Of course grid updating is minimum and weight of short path finder is relatively high, and there are no trees and buildings in this replay. 
### kanetaka2014/master-prof

> SHA-1: 69998af114361d0f6f7b0819e834527cee91f29c
> Final state: 7d8c1684f26658de03db3b71233f7b86
>  tc_UpdateGrid: 73.8944 Mc (55129x)
>  tc_ProcessShortRequests: 44.5952 Gc (985x)
>  tc_ProcessLongRequests: 401.983 Mc (947x)
>  tc_ProcessLongRequests_Loop: 401.538 Mc (5059x)
### na-Itms/pathfinding

> SHA-1: eba28529205f83330e0414d165d1589d0d67b36c
> Final state: e74b791dccc6b941d7d450a8a35ed708
>  tc_NavcellContainsGoal: 1993.25 Mc (22005277x)
>  tc_InitRegions: 541.174 Mc (2420x)
>  tc_MakeGoalReachable: 3973.67 Mc (3454x)
>  tc_UpdateGrid: 1127.26 Mc (848x)
>  tc_ProcessShortRequests: 46.8589 Gc (813x)
>  tc_ProcessLongRequests: 4975.86 Mc (1036x)
>  tc_ProcessLongRequests_Loop: 4975.29 Mc (3454x)
### kanetaka2014/PriorityQueue

> SHA-1: 723d7861b3d577de1080dae0eb5bb7b358981f35
> Final state: c605f26c2ec47865089df7825a9224ca
>  tc_NavcellContainsGoal: 1683.99 Mc (22389531x)
>  tc_InitRegions: 519.617 Mc (2420x)
>  tc_MakeGoalReachable: 3409.59 Mc (3421x)
>  tc_UpdateGrid: 870.519 Mc (848x)
>  tc_ProcessShortRequests: 36.5086 Gc (799x)
>  tc_ProcessLongRequests: 4257.64 Mc (984x)
>  tc_ProcessLongRequests_Loop: 4257.12 Mc (3421x)
